### PR TITLE
override node-sass dependency with sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "postcss": "^6.0.13"
   },
   "dependencies": {
-    "node-sass": "^4.5.3",
+    "node-sass": "npm:sass@^1.49.11",
     "resolve": "^1.1.6"
   }
 }


### PR DESCRIPTION
Doing this because node-sass is super deprecated but i don't know of a direct replacement for scssify in eos.